### PR TITLE
[refactor/fe-autobind] autobind 데코레이터 추가

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,18 @@
+//autobind 데코레이터 : 이벤트 핸들러의 this 바인딩을 자동으로 처리
+function autobind(
+	_target: any,
+	_methodName: string,
+	descriptor: PropertyDescriptor
+) {
+	const originalMethod = descriptor.value;
+	const adjDescriptor: PropertyDescriptor = {
+		configurable: true,
+		get() {
+			return originalMethod.bind(this);
+		},
+	};
+	return adjDescriptor;
+}
 //사용자의 입력을 받아 개별 프로젝트 신규 등록을 처리하는 클래스
 class ProjectInput {
 	templateElement: HTMLTemplateElement;
@@ -33,8 +48,9 @@ class ProjectInput {
 		this.hostElement.insertAdjacentElement("afterbegin", this.element);
 	}
 	private configure() {
-		this.element.addEventListener("submit", this.submitHandler.bind(this));
+		this.element.addEventListener("submit", this.submitHandler);
 	}
+	@autobind
 	private submitHandler(event: Event) {
 		event.preventDefault();
 		console.log(this.titleInputElement.value);


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [X]  Refactor
- [ ]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
기존의 이벤트 핸들러 this바인딩을 지우고,
다른 이벤트 핸들러에도 활용할 수 있게 바인딩을 자동으로 처리해주는 메서드 데코레이터를 제작하였습니다. 

# 느낀 점 및 어려운 점
- 데코레이터와 메서드 데코레이터에 대한 개념을 다시 공부하며 작업했습니다.
- 프로퍼티 접근자라는 말이 조금 생소해서 다시 공부하였습니다. 
<모던 자바스크립트 Deep Dive>의 16장 프로퍼티 어트리뷰트를 참고했습니다.
- 메서드 데코레이터애 대해 학습하며 해당 작업과 관련된 위키 페이지를 작성하였습니다.
  - [메서드 데코레이터 위키 페이지](https://github.com/shinnh2/drag_and_drop_ts/wiki/%EB%A9%94%EC%84%9C%EB%93%9C-%EB%8D%B0%EC%BD%94%EB%A0%88%EC%9D%B4%ED%84%B0)

# [option] 관련 알림사항
- 이 다음에는 다시 하던 작업으로 돌아가 유효성검사 기능을 추가할 예정입니다.