### PR TITLE
[feat/fe-prjFilter] 프로젝트 상태에 맞는 목록으로 렌더링(필터링) 추가

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -211,8 +211,13 @@ class ProjectList {
 		this.element = <HTMLElement>importedNode.firstElementChild!;
 		this.element.id = `${this.type}-projects`;
 		projectState.addListener((projects: Project[]) => {
-			this.assignedProjects = projects; //전체 상태에서 프로젝트 목록 전체를 받아옴
-			this.renderProjects(); //프로젝트 목록 내의 개별 프로젝트들을 렌더링해주는 함수
+			const relevantProjects = projects.filter((project) =>
+				this.type === "active"
+					? project.status === ProjectStatus.Active
+					: project.status === ProjectStatus.Finished
+			);
+			this.assignedProjects = relevantProjects;
+			this.renderProjects();
 		});
 		this.attach();
 		this.renderContent();
@@ -231,6 +236,7 @@ class ProjectList {
 		const listEl = <HTMLUListElement>(
 			this.element.querySelector(`#${this.type}-projects-list`)!
 		);
+		listEl.innerHTML = "";
 		for (let prjItem of this.assignedProjects) {
 			const listItem = document.createElement("li");
 			listItem.textContent = prjItem.title;


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 프로젝트 상태에 따라 활성화 또는 완료됨 목록으로 가도록 필터링하는 기능을 추가
- 프로젝트가 중복으로 등록되지 않고 한 번에 하나씩 추가되도록 초기화 기능 추가

# 느낀 점 및 어려운 점
- 어려운 점은 딱히 없었습니다.
- innerHTML을 사용하면 보안 상의 문제가 있다고 들었습니다. 이번에 한 작업처럼 만약 단순히 빈 문자열로 초기화하는 것이라면 문제가 되지 않지만, innerHTML의 대안으로 `replaceWith`등을 사용하는 방법도 있습니다. 

# [option] 관련 알림사항
- 이후에는 이제까지 한 작업의 중복되는 부분을 상속 등을 활용해 리팩토링하려고 합니다.
