### PR TITLE
[feat/fe-prjItem] 개별 프로젝트 아이템 클래스 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,11 @@
     </form>
   </template>
   <template id="single-project">
-    <li></li>
+    <li>
+      <h2></h2>
+      <h3></h3>
+      <p></p>
+    </li>
   </template>
   <template id="project-list">
     <section class="projects">

--- a/src/app.ts
+++ b/src/app.ts
@@ -119,9 +119,9 @@ abstract class Component<T extends HTMLElement, U extends HTMLElement> {
 		newElementId?: string
 	) {
 		this.templateElement = <HTMLTemplateElement>(
-			document.querySelector(templateId)!
+			document.getElementById(templateId)!
 		);
-		this.hostElement = <T>document.querySelector(hostElementId)!;
+		this.hostElement = <T>document.getElementById(hostElementId)!;
 		const importedNode = document.importNode(
 			this.templateElement.content,
 			true
@@ -150,7 +150,7 @@ class ProjectInput extends Component<HTMLDivElement, HTMLFormElement> {
 	peopleInputElement: HTMLInputElement;
 
 	constructor() {
-		super("#project-input", "#app", true, "user-input");
+		super("project-input", "app", true, "user-input");
 
 		this.titleInputElement = <HTMLInputElement>document.querySelector("#title");
 		this.descriptionInputElement = <HTMLInputElement>(
@@ -220,12 +220,38 @@ class ProjectInput extends Component<HTMLDivElement, HTMLFormElement> {
 	}
 }
 
+//ProjectItem : 프로젝트 목록 개별 프로젝트 아이템 렌더링
+class ProjectItem extends Component<HTMLUListElement, HTMLLIElement> {
+	private project: Project;
+
+	get persons() {
+		return this.project.people > 1
+			? `${this.project.people} persons`
+			: "1 person";
+	}
+
+	constructor(hostElementId: string, project: Project) {
+		super("single-project", hostElementId, false, project.id);
+		this.project = project;
+
+		this.configure();
+		this.renderContent();
+	}
+
+	configure() {}
+	renderContent() {
+		this.element.querySelector("h2")!.textContent = this.project.title;
+		this.element.querySelector("h3")!.textContent = `${this.persons} assigned`;
+		this.element.querySelector("p")!.textContent = this.project.description;
+	}
+}
+
 //ProjectList: 프로젝트 목록 렌더링
 class ProjectList extends Component<HTMLDivElement, HTMLElement> {
 	assignedProjects: Project[];
 
 	constructor(private type: "active" | "finished") {
-		super("#project-list", "#app", false, `${type}-projects`);
+		super("project-list", "app", false, `${type}-projects`);
 		this.assignedProjects = [];
 
 		this.configure();
@@ -256,9 +282,7 @@ class ProjectList extends Component<HTMLDivElement, HTMLElement> {
 		);
 		listEl.innerHTML = "";
 		for (let prjItem of this.assignedProjects) {
-			const listItem = document.createElement("li");
-			listItem.textContent = prjItem.title;
-			listEl.appendChild(listItem);
+			new ProjectItem(this.element.querySelector("ul")!.id, prjItem);
 		}
 	}
 }


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 개별 프로젝트 아이템을 생성하고 렌더링하는 클래스 ProjectItem 추가
- ProjectList의 기존 개별 아이템 생성 코드 대신 ProjectItem 클래스의 인스턴스 생성으로 대체
- index.html의 개별 프로젝트 아이템을 나타내는 템플릿의 li태그 안에 각각 제목, 인원수, 설명이 될 h2, h3, p 태그 생성

# 느낀 점 및 어려운 점
## 어렵지 않았지만 복잡해서 해결했던 것
- 모든 컴포넌트 클래스는 Component라는 클래스를 상속받고, 이 Component 클래스에서는 대상 element, 대상이 렌더링될 element의 id를 받아야 합니다. 기존에 이 부분을 querySelector로 받았더니 '#' 기호를 같이 받아야 해서 로직이 복잡해졌습니다. 그래서 모두 '#'을 제외한 id를 받는 것으로 고쳤습니다.
- 한글을 사용할 때에는 프로젝트의 인원수가 몇 명이든 그냥 `N명`으로 표기하면 되지만, 영어의 경우 인원수에 따라 `person인지 persons인지` 나타내줘야 합니다. 필요없는 작업이었지만 이 부분을 getter로 구현할 수 있으므로 getter 실습도 할겸 getter로 구현했습니다. 게터를 사용할 때의 주의할 점은 다음과 같습니다.
  - getter는 함수처럼 이름, 소괄호, 중괄호가 있어야 합니다. 그리고 사용할 값을 retrurn해야 합니다.
  - 그러나 사용할 때는 프로퍼티 처럼 `this.이름`으로 사용해야 합니다.

# [option] 관련 알림사항
- 다음은 이 프로젝트의 핵심이라고 할 수 있는 드래그 앤 드롭 기능을 본격적으로 작업하려고 합니다.
